### PR TITLE
Bump log4j-core in /ProyectosPruebas/JSF/BolsaTrabajoV5

### DIFF
--- a/ProyectosPruebas/JSF/BolsaTrabajoV5/pom.xml
+++ b/ProyectosPruebas/JSF/BolsaTrabajoV5/pom.xml
@@ -28,7 +28,7 @@
          <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.12.0</version>
+            <version>2.13.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Bumps log4j-core from 2.12.0 to 2.13.2.

Signed-off-by: dependabot[bot] <support@github.com>